### PR TITLE
Add profile picture selection using camera

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ app.*.map.json
 
 # Testing related
 /android
+
+group-42-analytic-engine-back/
+sprint4-app-report.pdf

--- a/lib/auth/bloc/auth_bloc.dart
+++ b/lib/auth/bloc/auth_bloc.dart
@@ -78,11 +78,20 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 
   // reegister
   Future<void> onRegister(
-    AuthRegisterRequest event,
-    Emitter<AuthState> emit,
-  ) async {
+      AuthRegisterRequest event,
+      Emitter<AuthState> emit,
+      ) async {
     emit(const AuthLoading());
+
     try {
+      String? profilePicUrl;
+
+      if (event.profileImageFile != null) {
+        profilePicUrl = await repository.uploadProfileImage(
+          event.profileImageFile!,
+        );
+      }
+
       final response = await repository.register(
         RegisterRequest(
           name: event.name,
@@ -90,10 +99,11 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
           email: event.email,
           password: event.password,
           semester: event.semester,
-          profilePic: event.profilePic,
+          profilePic: profilePicUrl,
           isSeller: event.isSeller,
         ),
       );
+
       emit(
         AuthAuthenticated(
           user: response.user,

--- a/lib/auth/bloc/auth_event.dart
+++ b/lib/auth/bloc/auth_event.dart
@@ -1,13 +1,14 @@
 // define los eventos que llegan al bloc de auth
 
 import 'package:equatable/equatable.dart';
+import 'dart:io';
 
 // evento basico para el bloc
 abstract class AuthEvent extends Equatable {
   const AuthEvent();
 
   @override
-  List<Object> get props => [];
+  List<Object?> get props => [];
 }
 
 // evento para restaurar la sesion (en caso de haber un JWT)
@@ -33,7 +34,7 @@ class AuthRegisterRequest extends AuthEvent {
   final String email;
   final String password;
   final int? semester;
-  final String? profilePic;
+  final File? profileImageFile;
   final bool isSeller;
 
   const AuthRegisterRequest({
@@ -42,18 +43,18 @@ class AuthRegisterRequest extends AuthEvent {
     required this.email,
     required this.password,
     this.semester,
-    this.profilePic,
-    this.isSeller = false, // por defecto nadie es vendedor
+    this.profileImageFile,
+    this.isSeller = false,
   });
 
   @override
-  List<Object> get props => [
+  List<Object?> get props => [
     name,
     lastName,
     email,
     password,
-    ?semester,
-    ?profilePic,
+    semester,
+    profileImageFile?.path,
     isSeller,
   ];
 }

--- a/lib/auth/data/auth_api_client.dart
+++ b/lib/auth/data/auth_api_client.dart
@@ -2,6 +2,7 @@
 
 import 'package:dio/dio.dart';
 import '../models/auth_models.dart';
+import 'dart:io';
 
 
 class AuthApiClient {
@@ -40,4 +41,58 @@ class AuthApiClient {
     final response = await dio.delete('/auth/delete-account', data: request.toJson());
     return MessageResponse.fromJson(response.data as Map<String, dynamic>);
   }
+
+  Future<Map<String, dynamic>> getCloudinarySignature({
+    String? folder,
+  }) async {
+    final response = await dio.post(
+      '/uploads/cloudinary-signature',
+      data: {
+        if (folder != null) 'folder': folder,
+      },
+    );
+
+    final data = response.data;
+    if (data is Map<String, dynamic>) return data;
+
+    throw Exception('Invalid cloudinary signature response.');
+  }
+
+  Future<String> uploadProfileImageToCloudinary(File imageFile) async {
+    final sig = await getCloudinarySignature(
+      folder: 'unimarket/profile_pictures',
+    );
+
+    final cloudName = sig['cloud_name'] ?? sig['cloudName'];
+    final apiKey = sig['api_key'] ?? sig['apiKey'];
+    final timestamp = sig['timestamp'];
+    final signature = sig['signature'];
+    final folder = sig['folder'];
+
+    final uploadDio = Dio();
+
+    final formData = FormData.fromMap({
+      'file': await MultipartFile.fromFile(
+        imageFile.path,
+        filename: imageFile.path.split('/').last,
+      ),
+      'api_key': apiKey,
+      'timestamp': timestamp,
+      'signature': signature,
+      if (folder != null) 'folder': folder,
+    });
+
+    final uploadResponse = await uploadDio.post(
+      'https://api.cloudinary.com/v1_1/$cloudName/image/upload',
+      data: formData,
+    );
+
+    final uploadData = uploadResponse.data;
+    if (uploadData is Map<String, dynamic>) {
+      return (uploadData['secure_url'] ?? uploadData['url']) as String;
+    }
+
+    throw Exception('Invalid Cloudinary upload response.');
+  }
+
 }

--- a/lib/auth/models/auth_models.dart
+++ b/lib/auth/models/auth_models.dart
@@ -79,30 +79,44 @@ class DeleteAccountRequest {
 class AuthUser {
   final int id;
   final String name;
+  final String lastName;
   final String email;
+  final int? semester;
+  final String? profilePic;
   final bool isSeller;
 
   // se instancia el objeto
   const AuthUser({
     required this.id,
     required this.name,
+    required this.lastName,
     required this.email,
+    this.semester,
+    this.profilePic,
     required this.isSeller,
   });
 
   // el factory es para que devuelva un objeto de la clase AuthUser
   factory AuthUser.fromJson(Map<String, dynamic> json) => AuthUser(
-    id: json['id'] as int,
-    name: json['name'] as String,
-    email: json['email'] as String,
-    isSeller: json['is_seller'] as bool ?? false,
+    id: (json['id'] as num).toInt(),
+    name: json['name'] as String? ?? '',
+    lastName: json['last_name'] as String? ?? '',
+    email: json['email'] as String? ?? '',
+    semester: json['semester'] is num
+        ? (json['semester'] as num).toInt()
+        : null,
+    profilePic: json['profile_pic'] as String?,
+    isSeller: json['is_seller'] as bool? ?? false,
   );
 
   // se mappea el objeto a un json
   Map<String, dynamic> toJson() => {
     'id': id,
     'name': name,
+    'last_name': lastName,
     'email': email,
+    if (semester != null) 'semester': semester,
+    if (profilePic != null) 'profile_pic': profilePic,
     'is_seller': isSeller,
   };
 }

--- a/lib/auth/repositories/auth_repository.dart
+++ b/lib/auth/repositories/auth_repository.dart
@@ -6,6 +6,7 @@ import 'package:isis3510_group42_flutter_app/products/data/listings_cache.dart';
 import '../data/auth_api_client.dart';
 import '../data/token_storage.dart';
 import '../models/auth_models.dart';
+import 'dart:io';
 
 class AuthRepository {
   final AuthApiClient api;
@@ -103,6 +104,16 @@ class AuthRepository {
   Future<void> logout() async {
     await Future.wait([listingsCache.clearSessionCache(), storage.clear()]);
   }
+
+  Future<String> uploadProfileImage(File imageFile) async {
+    final isOnline = await connectivityService.isConnected;
+    if (!isOnline) {
+      throw ConnectionError('No internet connection. Please try again later');
+    }
+
+    return api.uploadProfileImageToCloudinary(imageFile);
+  }
+
 }
 
 // Excepción personalizada para errores de conexión

--- a/lib/auth/screens/register_screen.dart
+++ b/lib/auth/screens/register_screen.dart
@@ -6,6 +6,8 @@ import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../bloc/auth_state.dart';
 import '../../theme/app_theme.dart';
+import 'dart:io';
+import 'package:image_picker/image_picker.dart';
 
 class RegisterScreen extends StatefulWidget {
   const RegisterScreen({super.key});
@@ -22,6 +24,8 @@ class _RegisterScreenState extends State<RegisterScreen> {
   final passwordControllr = TextEditingController();
   final confirmControler = TextEditingController();
   final semesterController = TextEditingController();
+  final picker = ImagePicker();
+  File? selectedProfileImage;
   bool isSeller = false;
   bool obscurePassword = true;
   bool obscureConfirm = true;
@@ -54,8 +58,99 @@ class _RegisterScreenState extends State<RegisterScreen> {
         semester: semesterController.text.isNotEmpty
             ? int.tryParse(semesterController.text)
             : null,
+        profileImageFile: selectedProfileImage,
         isSeller: isSeller,
       ),
+    );
+  }
+
+  Future<void> pickProfileImage(ImageSource source) async {
+    final picked = await picker.pickImage(
+      source: source,
+      imageQuality: 80,
+      maxWidth: 800,
+    );
+
+    if (picked == null) return;
+
+    setState(() {
+      selectedProfileImage = File(picked.path);
+    });
+  }
+
+  void showProfileImageSourceSheet() {
+    showModalBottomSheet(
+      context: context,
+      builder: (_) => SafeArea(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            ListTile(
+              leading: const Icon(Icons.camera_alt_outlined),
+              title: const Text('Take a profile photo'),
+              subtitle: const Text('Uses the phone camera sensor'),
+              onTap: () {
+                Navigator.pop(context);
+                pickProfileImage(ImageSource.camera);
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.photo_library_outlined),
+              title: const Text('Choose from gallery'),
+              onTap: () {
+                Navigator.pop(context);
+                pickProfileImage(ImageSource.gallery);
+              },
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void removeProfileImage() {
+    setState(() {
+      selectedProfileImage = null;
+    });
+  }
+
+  Widget buildProfilePhotoPicker() {
+    return Column(
+      children: [
+        GestureDetector(
+          onTap: showProfileImageSourceSheet,
+          child: CircleAvatar(
+            radius: 48,
+            backgroundColor: AppColors.inputFill,
+            backgroundImage: selectedProfileImage != null
+                ? FileImage(selectedProfileImage!)
+                : null,
+            child: selectedProfileImage == null
+                ? const Icon(
+              Icons.camera_alt_outlined,
+              size: 36,
+              color: AppColors.primaryBlue,
+            )
+                : null,
+          ),
+        ),
+        const SizedBox(height: 8),
+        TextButton.icon(
+          onPressed: showProfileImageSourceSheet,
+          icon: const Icon(Icons.add_a_photo_outlined),
+          label: Text(
+            selectedProfileImage == null
+                ? 'Add profile photo'
+                : 'Change profile photo',
+          ),
+        ),
+        if (selectedProfileImage != null)
+          TextButton.icon(
+            onPressed: removeProfileImage,
+            icon: const Icon(Icons.delete_outline),
+            label: const Text('Remove photo'),
+          ),
+      ],
     );
   }
 
@@ -108,6 +203,14 @@ class _RegisterScreenState extends State<RegisterScreen> {
                     ),
 
                     const SizedBox(height: 36),
+
+                    const SizedBox(height: 24),
+
+                    fieldLabel('Profile photo (optional)'),
+                    const SizedBox(height: 8),
+                    buildProfilePhotoPicker(),
+
+                    const SizedBox(height: 24),
 
                     //First
                     fieldLabel('First Name'),

--- a/lib/home/screens/home_screen.dart
+++ b/lib/home/screens/home_screen.dart
@@ -47,7 +47,7 @@ class _HomeScreenViewState extends State<_HomeScreenView> {
       const BrowseListingsScreen(),
       const ChatsScreen(),
       const SellerProductsScreen(),
-      _ProfileTab(userName: user?.name ?? 'User'),
+      _ProfileTab(user: user),
     ];
 
     return BlocListener<ProductBloc, ProductState>(
@@ -110,12 +110,15 @@ class _HomeScreenViewState extends State<_HomeScreenView> {
 }
 
 class _ProfileTab extends StatelessWidget {
-  final String userName;
+  final AuthUser? user;
 
-  const _ProfileTab({required this.userName});
+  const _ProfileTab({required this.user});
 
   @override
   Widget build(BuildContext context) {
+    final userName = user?.name ?? 'User';
+    final profilePic = user?.profilePic;
+
     return Scaffold(
       appBar: AppBar(title: Text('Welcome, $userName')),
       body: Padding(
@@ -123,6 +126,41 @@ class _ProfileTab extends StatelessWidget {
         child: SingleChildScrollView(
           child: Column(
             children: [
+              CircleAvatar(
+                radius: 52,
+                backgroundColor: AppColors.inputFill,
+                backgroundImage: profilePic != null && profilePic.isNotEmpty
+                    ? NetworkImage(profilePic)
+                    : null,
+                child: profilePic == null || profilePic.isEmpty
+                    ? const Icon(
+                  Icons.person_outline,
+                  size: 48,
+                  color: AppColors.primaryBlue,
+                )
+                    : null,
+              ),
+              const SizedBox(height: 12),
+              Text(
+                userName,
+                style: const TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.labelDark,
+                ),
+              ),
+              if (user?.email != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  user!.email,
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.grey.shade600,
+                  ),
+                ),
+              ],
+              const SizedBox(height: 28),
+
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton(
@@ -166,7 +204,6 @@ class _ProfileTab extends StatelessWidget {
                     padding: const EdgeInsets.symmetric(vertical: 14),
                   ),
                   onPressed: () {
-                    // Tira una excepcion real para simular un crash y probar el data pipeline
                     throw Exception(
                       'BQ1 simulated crash — ProfileTab test button',
                     );
@@ -188,9 +225,6 @@ class _ProfileTab extends StatelessWidget {
                     padding: const EdgeInsets.symmetric(vertical: 14),
                   ),
                   onPressed: () {
-                    // Lanza un error asíncrono no capturado — sale del widget tree
-                    // y es atrapado por PlatformDispatcher.instance.onError en main.dart,
-                    // simulando un crash fatal de verdad.
                     Future.error(
                       StateError(
                         'BQ1 simulated FATAL crash — async unhandled error',


### PR DESCRIPTION
This PR adds profile picture selection during user registration using the device camera or gallery.

Changes included:
- Added profile image picker in the register screen.
- Uploaded the selected image to Cloudinary.
- Sent the uploaded image URL as profile_pic during registration.
- Updated AuthUser to store and restore profile_pic.
- Displayed the profile picture in the Profile tab.